### PR TITLE
fix panics

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -3,7 +3,7 @@ package gocb
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/couchbaselabs/gocb/gocbcore"
+	"github.com/VerveWireless/gocb/gocbcore"
 	"net/http"
 	"time"
 )

--- a/transcoding_test.go
+++ b/transcoding_test.go
@@ -83,8 +83,8 @@ func TestDecodeString(t *testing.T) {
 }
 
 func TestDecodeBadType(t *testing.T) {
-	var testOut string
-	err := defaultTranscoder.Decode(jsonNumStr, 0x2000000, &testOut)
+	var testOut int
+	err := defaultTranscoder.Decode(jsonStrStr, 0x2000000, &testOut)
 	if err == nil {
 		t.Errorf("Decoding succeeded but should have failed")
 	}


### PR DESCRIPTION
Instead of trying to cast an interface to a string, and panicking when you can't, switch on the interface's type.
